### PR TITLE
Fix fallback for small prompts

### DIFF
--- a/int8_quant.py
+++ b/int8_quant.py
@@ -506,4 +506,3 @@ if _COMFY_OPS_AVAILABLE:
             if dims == 2: return cls.Conv2d(*args, **kwargs)
             elif dims == 3: return cls.Conv3d(*args, **kwargs)
             else: raise ValueError(f"unsupported dimensions: {dims}")
-


### PR DESCRIPTION
if you use FP16 weights, bias would be BF16 and then poof