### PR TITLE
Add per-row INT8 weight quantization with fused Triton kernel

### DIFF
--- a/int8_fused_kernel.py
+++ b/int8_fused_kernel.py
@@ -233,3 +233,140 @@ def triton_int8_linear(x: torch.Tensor, weight: torch.Tensor, weight_scale, bias
     
     # 6. Reshape output
     return output.reshape(x_shape_orig[:-1] + (N,))
+
+
+# =============================================================================
+# Kernel 3: INT8 GEMM + Fused Dequant with Per-Row Weight Scales
+# =============================================================================
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_SIZE_M': 8}, num_stages=3, num_warps=8),
+        triton.Config({'BLOCK_M': 64,  'BLOCK_N': 256, 'BLOCK_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4, num_warps=4),
+        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4, num_warps=4),
+        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64,  'BLOCK_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4, num_warps=4),
+        triton.Config({'BLOCK_M': 64,  'BLOCK_N': 128, 'BLOCK_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4, num_warps=4),
+        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32,  'BLOCK_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4, num_warps=4),
+    ],
+    key=['M', 'N', 'K'],
+)
+@triton.jit
+def _int8_matmul_dequant_per_row_kernel(
+    # Pointers
+    a_ptr, b_ptr, c_ptr,
+    a_scale_ptr, b_scale_ptr, bias_ptr,
+    # Matrix Dimensions
+    M, N, K,
+    # Strides
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    # Meta-parameters
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    HAS_BIAS: tl.constexpr
+):
+    """
+    Computes: C = ((A * B) * (scale_a[:, None] * scale_b[None, :])) + bias
+    A: [M, K] int8, scale_a: [M, 1] per-row activation scales
+    B: [N, K] int8, scale_b: [N, 1] per-row weight scales
+    """
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # 1. Prepare Pointers for A and B
+    offs_am = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
+    offs_bn = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    offs_k = tl.arange(0, BLOCK_K)
+
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    # 2. Main Loop (Accumulate in Int32)
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.int32)
+
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
+        accumulator += tl.dot(a, b)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+
+    # 3. Fused Epilogue (Dequantize & Bias)
+
+    # A Scale is per-row [M, 1]
+    scale_a = tl.load(a_scale_ptr + offs_am)  # Vector [BLOCK_M]
+
+    # B Scale is per-row [N, 1] (the key difference from the scalar kernel)
+    scale_b = tl.load(b_scale_ptr + offs_bn)  # Vector [BLOCK_N]
+
+    c = accumulator.to(tl.float32)
+
+    # Outer product of scales: [BLOCK_M, 1] * [1, BLOCK_N]
+    total_scale = scale_a[:, None] * scale_b[None, :]
+
+    c = c * total_scale
+
+    if HAS_BIAS:
+        bias = tl.load(bias_ptr + offs_bn)
+        c = c + bias[None, :]
+
+    # 4. Store Result
+    c_ptrs = c_ptr + stride_cm * offs_am[:, None] + stride_cn * offs_bn[None, :]
+    c_mask = (offs_am[:, None] < M) & (offs_bn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+# =============================================================================
+# Python Wrapper (Per-Row Weight Scales)
+# =============================================================================
+
+def triton_int8_linear_per_row(x: torch.Tensor, weight: torch.Tensor, weight_scale: torch.Tensor, bias=None, compute_dtype=torch.float16):
+    """
+    Fused pipeline for W8A8 Linear Layer with per-row weight quantization.
+    weight_scale: [N, 1] per-row scales
+    """
+    # 1. Flatten inputs if 3D
+    x_shape_orig = x.shape
+    x_2d = x.reshape(-1, x_shape_orig[-1])
+
+    M, K = x_2d.shape
+    N = weight.shape[0]
+
+    # 2. Dynamic Activation Quantization
+    x_int8, x_scale = triton_quantize_rowwise(x_2d)
+
+    # 3. Allocate Output
+    output = torch.empty((M, N), device=x.device, dtype=compute_dtype)
+
+    # 4. Prepare weight scales - flatten [N, 1] -> [N] for kernel
+    ws = weight_scale.reshape(N).contiguous()
+
+    # 5. Fused GEMM + Per-Row Dequant
+    grid = lambda META: (triton.cdiv(M, META['BLOCK_M']) * triton.cdiv(N, META['BLOCK_N']), )
+
+    has_bias = bias is not None
+    bias_ptr = bias if has_bias else x  # Dummy pointer if None
+
+    _int8_matmul_dequant_per_row_kernel[grid](
+        a_ptr=x_int8,
+        b_ptr=weight,
+        c_ptr=output,
+        a_scale_ptr=x_scale,
+        b_scale_ptr=ws,
+        bias_ptr=bias_ptr,
+        M=M, N=N, K=K,
+        stride_am=x_int8.stride(0), stride_ak=x_int8.stride(1),
+        stride_bk=weight.stride(1), stride_bn=weight.stride(0),
+        stride_cm=output.stride(0), stride_cn=output.stride(1),
+        HAS_BIAS=has_bias
+    )
+
+    # 6. Reshape output
+    return output.reshape(x_shape_orig[:-1] + (N,))

--- a/int8_quant.py
+++ b/int8_quant.py
@@ -5,6 +5,8 @@ import torch.nn.functional as F
 # Add this at the top of your file
 try:
     from .int8_fused_kernel import triton_int8_linear
+    from .int8_fused_kernel import triton_int8_linear_per_row
+    from .int8_fused_kernel import triton_quantize_rowwise
     _TRITON_AVAILABLE = True
 except ImportError:
     _TRITON_AVAILABLE = False
@@ -70,6 +72,37 @@ def int8_forward_dynamic(x: Tensor, weight: Tensor, weight_scale: float | Tensor
     # Dequantize: (res * weight_scale * x_scale)
     # Note: Creating intermediate Float tensors here is VRAM heavy
     res_scaled = res.float().mul_(weight_scale * x_scale).to(compute_dtype)
+    
+    if bias is not None:
+        res_scaled = res_scaled + bias.to(compute_dtype)
+    return res_scaled
+
+
+@torch.no_grad()
+def int8_forward_dynamic_per_row(x: Tensor, weight: Tensor, weight_scale: Tensor, bias: Tensor | None, compute_dtype: torch.dtype) -> Tensor:
+    """Forward with dynamic per-token activation quantization and per-row weight quantization.
+    
+    Args:
+        x: Input activations [batch, in_features]
+        weight: INT8 weight matrix [out_features, in_features]
+        weight_scale: Per-row weight scales [out_features, 1]
+        bias: Optional bias
+        compute_dtype: Output dtype
+    """
+    # --- FAST PATH: Triton Fused Kernel (per-row) ---
+    if _TRITON_AVAILABLE and x.is_cuda:
+        return triton_int8_linear_per_row(x, weight, weight_scale, bias, compute_dtype)
+
+    # --- SLOW PATH: Standard PyTorch ---
+    x_8, x_scale = quantize_int8_axiswise(x, dim=-1)
+
+    # INT8 Matmul (Outputs Int32)
+    res = torch._int_mm(x_8, weight.T)  # [batch, out_features]
+    
+    # Dequantize with per-row weight scales
+    # res[i,j] = sum_k(x_8[i,k] * weight[j,k]) * x_scale[i] * weight_scale[j]
+    # Broadcasting: res * x_scale * weight_scale.T
+    res_scaled = res.float().mul_(x_scale).mul_(weight_scale.T).to(compute_dtype)
     
     if bias is not None:
         res_scaled = res_scaled + bias.to(compute_dtype)
@@ -312,6 +345,7 @@ if _COMFY_OPS_AVAILABLE:
                 super().__init__(*args, **kwargs)
                 self.weight_scale = None
                 self._is_quantized = False
+                self._is_per_row = False  # Track quantization granularity
                 self.compute_dtype = torch.bfloat16
                 self.lora_A = None
                 self.lora_B = None
@@ -341,9 +375,18 @@ if _COMFY_OPS_AVAILABLE:
                         Int8TensorwiseOps._is_prequantized = True # Found a quantized layer
                         
                         if isinstance(weight_scale, torch.Tensor):
-                            self.weight_scale = weight_scale.float().item() if weight_scale.numel() == 1 else weight_scale.float()
+                            if weight_scale.numel() == 1:
+                                self.weight_scale = weight_scale.float().item()
+                                self._is_per_row = False
+                            elif weight_scale.dim() == 2 and weight_scale.shape[1] == 1:
+                                self.weight_scale = weight_scale.float()
+                                self._is_per_row = True
+                            else:
+                                self.weight_scale = weight_scale.float()
+                                self._is_per_row = False
                         else:
                             self.weight_scale = float(weight_scale)
+                            self._is_per_row = False
                             
                     elif weight_tensor.dtype in (torch.float16, torch.bfloat16, torch.float32):
                         # Load High-Precision
@@ -383,6 +426,7 @@ if _COMFY_OPS_AVAILABLE:
                             self.weight = nn.Parameter(q_weight.cpu(), requires_grad=False)
                             self.weight_scale = q_scale.cpu() if isinstance(q_scale, torch.Tensor) else q_scale
                             self._is_quantized = True
+                            self._is_per_row = False
                     else:
                         self._is_quantized = False
                         self.weight = nn.Parameter(weight_tensor, requires_grad=False)
@@ -470,7 +514,10 @@ if _COMFY_OPS_AVAILABLE:
                 x_2d = x.reshape(-1, x_shape[-1])
                 
                 if x_2d.shape[0] > 16:
-                    y = int8_forward_dynamic(x_2d, weight, w_scale, bias, compute_dtype)
+                    if self._is_per_row:
+                        y = int8_forward_dynamic_per_row(x_2d, weight, w_scale, bias, compute_dtype)
+                    else:
+                        y = int8_forward_dynamic(x_2d, weight, w_scale, bias, compute_dtype)
                 else:
                     # Small batch fallback
                     w_float = dequantize(weight, w_scale).to(x.dtype)


### PR DESCRIPTION
Hello, I've created INT8 quantized versions of the Flux2 klein models. I first tried to load them with your ComfyUI node but noticed that my weights used per-row quantization. I was able to modify your code to support this quantization format and verified it. I have not verified other INT8 weights.

https://huggingface.co/vistralis/FLUX.2-klein-base-9b-INT8-transformer
https://huggingface.co/vistralis/FLUX.2-klein-base-4b-INT8-transformer
https://huggingface.co/vistralis/FLUX.2-klein-9b-INT8-transformer
https://huggingface.co/vistralis/FLUX.2-klein-4b-INT8-transformer

- Add int8_forward_dynamic_per_row for per-row weight scale dequantization
- Add fused Triton GEMM kernel with per-row weight scale epilogue
- Auto-detect per-row vs per-tensor scale shape during weight loading
