### PR TITLE
Several bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/int8_lora.py
+++ b/int8_lora.py
@@ -30,7 +30,20 @@ class INT8GroupedLora:
 
     def apply_loras(self, model, **kwargs):
         model_patcher = model.clone()
-        
+
+        # ComfyUI's ModelPatcher.clone() builds a fresh patcher object and does
+        # NOT carry over arbitrary attributes set on the source patcher (e.g.
+        # the _safetensors_metadata stash from UNetLoaderINTW8A8). Without this,
+        # downstream nodes like INT8ModelSave lose the source safetensors
+        # metadata (int8_quantized flag, model_type, LTX2 'config', etc.) and
+        # produce a corrupted/unloadable checkpoint.
+        for attr in ("_safetensors_metadata", "_int8_source_metadata"):
+            if hasattr(model, attr) and not hasattr(model_patcher, attr):
+                try:
+                    setattr(model_patcher, attr, getattr(model, attr))
+                except Exception:
+                    pass
+
         # Get key mappings from ComfyUI's framework
         key_map = {}
         if model_patcher.model.model_type.name != "ModelType.CLIP":

--- a/int8_quant.py
+++ b/int8_quant.py
@@ -252,6 +252,9 @@ if _COMFY_OPS_AVAILABLE:
                             H = build_hadamard(CONVROT_GROUP_SIZE, device=w_gpu.device, dtype=w_gpu.dtype)
                             w_gpu = rotate_weight(w_gpu, H, group_size=CONVROT_GROUP_SIZE)
                             self._use_convrot = True
+                            # Stamp the active groupsize so INT8ModelSave can
+                            # round-trip it deterministically.
+                            self._convrot_groupsize = CONVROT_GROUP_SIZE
                         except ImportError as e:
                             logging.warning(f"INT8 Fast: ConvRot enabled but convrot module error: {e}")
 
@@ -337,15 +340,16 @@ if _COMFY_OPS_AVAILABLE:
                 # Pop input_scale to clean state_dict, but ignore it
                 _ = state_dict.pop(input_scale_key, None)
                 
+                quant_conf_parsed = None
                 if comfy_quant_tensor is not None:
                     try:
                         import json
-                        quant_conf = json.loads(bytes(comfy_quant_tensor.tolist()).decode('utf-8'))
-                        if quant_conf.get("convrot", False):
+                        quant_conf_parsed = json.loads(bytes(comfy_quant_tensor.tolist()).decode('utf-8'))
+                        if quant_conf_parsed.get("convrot", False):
                             self._use_convrot = True
                             Int8TensorwiseOps.enable_convrot = True  # Propagate globally for LoRA
-                            if "convrot_groupsize" in quant_conf:
-                                self._convrot_groupsize = quant_conf["convrot_groupsize"]
+                            if "convrot_groupsize" in quant_conf_parsed:
+                                self._convrot_groupsize = int(quant_conf_parsed["convrot_groupsize"])
                                 Int8TensorwiseOps._global_convrot_groupsize = self._convrot_groupsize
                     except Exception:
                         pass
@@ -373,25 +377,30 @@ if _COMFY_OPS_AVAILABLE:
                         self._is_quantized = True
                         self.weight = nn.Parameter(weight_tensor, requires_grad=False)
                         Int8TensorwiseOps._is_prequantized = True # Found a quantized layer
-                        
+
+                        # Optional explicit hint from saved comfy_quant
+                        per_row_hint = None
+                        if isinstance(quant_conf_parsed, dict) and "per_row" in quant_conf_parsed:
+                            per_row_hint = bool(quant_conf_parsed["per_row"])
+
                         if isinstance(weight_scale, torch.Tensor):
                             if weight_scale.numel() == 1:
                                 # Scalar scale — store as float for speed
                                 self._weight_scale_scalar = weight_scale.float().item()
                                 self.weight_scale = None
-                                self._is_per_row = False
+                                self._is_per_row = False if per_row_hint is None else per_row_hint
                             elif weight_scale.dim() == 2 and weight_scale.shape[1] == 1:
                                 self.register_buffer('weight_scale', weight_scale.float())
                                 self._weight_scale_scalar = None
-                                self._is_per_row = True
+                                self._is_per_row = True if per_row_hint is None else per_row_hint
                             else:
                                 self.register_buffer('weight_scale', weight_scale.float())
                                 self._weight_scale_scalar = None
-                                self._is_per_row = False
+                                self._is_per_row = False if per_row_hint is None else per_row_hint
                         else:
                             self._weight_scale_scalar = float(weight_scale)
                             self.weight_scale = None
-                            self._is_per_row = False
+                            self._is_per_row = False if per_row_hint is None else per_row_hint
                             
                     elif weight_tensor.dtype in (torch.float16, torch.bfloat16, torch.float32, torch.float8_e4m3fn):
                         # Load High-Precision
@@ -442,6 +451,10 @@ if _COMFY_OPS_AVAILABLE:
                                     H = build_hadamard(CONVROT_GROUP_SIZE, device=w_gpu.device, dtype=w_gpu.dtype)
                                     w_gpu = rotate_weight(w_gpu, H, group_size=CONVROT_GROUP_SIZE)
                                     self._use_convrot = True
+                                    # Stamp the active groupsize on the module so
+                                    # INT8ModelSave can serialize it deterministically
+                                    # (instead of relying on the loader's default).
+                                    self._convrot_groupsize = CONVROT_GROUP_SIZE
                                 except ImportError as e:
                                     import logging
                                     logging.warning(f"INT8 Fast: ConvRot enabled but convrot module error: {e}")

--- a/int8_save.py
+++ b/int8_save.py
@@ -1,10 +1,44 @@
 import folder_paths
 import comfy.sd
 import comfy.model_patcher
+import comfy.model_management
 import json
 import os
+import logging
 import torch
 from comfy.cli_args import args
+
+
+def _resolve_source_metadata(model):
+    """Walk the patcher clone chain and the inner model object to recover the
+    original safetensors metadata that was stashed by UNetLoaderINTW8A8.
+
+    ComfyUI's ``ModelPatcher.clone()`` builds a fresh patcher and does not copy
+    over arbitrary attributes set on the source patcher. INT8GroupedLora and
+    other downstream nodes call ``model.clone()``, which would otherwise drop
+    the ``_safetensors_metadata`` stash and produce a checkpoint missing the
+    ``int8_quantized`` / ``int8_model_type`` / ``config`` (LTX2) flags that the
+    loader relies on for round-trips.
+    """
+    seen = set()
+
+    def _walk(m):
+        if m is None or id(m) in seen:
+            return None
+        seen.add(id(m))
+        meta = getattr(m, "_safetensors_metadata", None)
+        if isinstance(meta, dict) and meta:
+            return meta
+        inner = getattr(m, "model", None)
+        if inner is not None:
+            inner_meta = getattr(inner, "_int8_source_metadata", None)
+            if isinstance(inner_meta, dict) and inner_meta:
+                return inner_meta
+        parent = getattr(m, "parent", None)
+        return _walk(parent)
+
+    return _walk(model)
+
 
 class INT8ModelSave:
     def __init__(self):
@@ -28,10 +62,18 @@ class INT8ModelSave:
             prompt_info = json.dumps(prompt)
 
         metadata = {}
-        # Preserve source safetensors metadata (int8_quantized, int8_model_type, ltx2 config, etc.)
-        src_meta = getattr(model, "_safetensors_metadata", None)
+        # Preserve source safetensors metadata (int8_quantized, int8_model_type,
+        # ltx2 config, etc.). Walk the patcher chain because INT8GroupedLora's
+        # clone strips this attribute from the local patcher.
+        src_meta = _resolve_source_metadata(model)
         if isinstance(src_meta, dict):
             metadata.update(src_meta)
+        if not src_meta:
+            logging.warning(
+                "INT8 Save: source safetensors metadata could not be located on the patcher chain. "
+                "The output checkpoint will be saved without int8_quantized/int8_model_type/config metadata, "
+                "which may break re-loading for some models (notably LTX2)."
+            )
         # if not args.disable_metadata:
         #     metadata["prompt"] = prompt_info
         #     if extra_pnginfo is not None:
@@ -42,7 +84,7 @@ class INT8ModelSave:
         output_checkpoint = os.path.join(full_output_folder, output_checkpoint)
 
         extra_keys = {}
-        
+
         patched_modules = []
         patched_module_ids = set()
 
@@ -67,7 +109,6 @@ class INT8ModelSave:
             if hasattr(model_patcher, "model") and hasattr(model_patcher.model, "named_modules"):
                 yield from model_patcher.model.named_modules()
 
-        
         # Finalize any deferred INT8 layers (Aimdo/Windows deferred-load path sets
         # _pending_int8_finalize instead of quantizing immediately). Without this,
         # those modules still have _is_quantized=False at save time and no
@@ -76,7 +117,44 @@ class INT8ModelSave:
         if finalize_fn is not None:
             finalize_fn()
 
-        # We need to peek at the model's actual modules to save comfy_quant and weight_scale
+        # CRITICAL: Apply any pending LoRA / model patches BEFORE collecting
+        # extra_keys and BEFORE save_checkpoint runs its own load_models_gpu().
+        #
+        # Why: when LoRAs were stacked via INT8GroupedLora (or the standard
+        # LoRA loader), the patches live on the model patcher and are only
+        # baked into the int8 weights when ``patch_model`` runs. ``save_checkpoint``
+        # internally calls ``load_models_gpu`` which does trigger the bake, but
+        # we also need to observe the post-bake module state to emit accurate
+        # ``comfy_quant`` / scalar ``weight_scale`` extra_keys (and to be sure
+        # ``module.comfy_patched_weights`` is set so ``model_state_dict_for_saving``
+        # emits the int8 weight directly instead of wrapping it in a
+        # LazyCastingParam, which assumes float dtypes).
+        #
+        # ``force_full_load=True`` keeps every patched layer on-device so we
+        # see consistent int8 weights for every module, even on lowvram setups.
+        try:
+            comfy.model_management.load_models_gpu([model], force_full_load=True)
+        except Exception as e:
+            logging.warning(
+                f"INT8 Save: full-load pre-pass failed ({e}); falling back to "
+                "default load_models_gpu without force_full_load."
+            )
+            try:
+                comfy.model_management.load_models_gpu([model])
+            except Exception as e2:
+                logging.warning(
+                    f"INT8 Save: load_models_gpu fallback also failed ({e2}); "
+                    "continuing best-effort. The saved checkpoint may be "
+                    "incomplete if LoRA patches were not applied."
+                )
+
+        # Re-finalize after load_models_gpu in case any aimdo deferred layers
+        # were materialized only during the load pass.
+        if finalize_fn is not None:
+            finalize_fn()
+
+        # Collect comfy_quant and (scalar) weight_scale extra_keys based on
+        # the post-patch module state.
         if hasattr(model, "model"):
             for name, module in iter_model_modules(model):
                 if module_has_int8_param(module):
@@ -84,26 +162,43 @@ class INT8ModelSave:
                     # with requires_grad=True by default, which is invalid for
                     # int8 tensors. Mark all int8 modules for direct save.
                     mark_module_for_direct_save(module)
-                
-                # Only log modules that are INT8-aware (have _is_quantized attribute)
-                # if hasattr(module, '_is_quantized'):
-                #     print(f"[INT8Save] int8 module: '{name}' | _is_quantized={module._is_quantized}")
 
                 if getattr(module, "_is_quantized", False):
-                    # 1. Comfy Quant Hint
-                    quant_conf = {"convrot": getattr(module, "_use_convrot", False)}
-                    if hasattr(module, "_convrot_groupsize"):
-                        quant_conf["convrot_groupsize"] = module._convrot_groupsize
-                        
-                    # Prepend 'model.' as comfy.sd.save_checkpoint typically adds this to all weights
-                    # but may not add it to extra_keys. This ensures they stay alongside weights.
+                    use_convrot = bool(getattr(module, "_use_convrot", False))
+                    quant_conf = {"convrot": use_convrot}
+                    # Always emit a groupsize when convrot is on, even if the
+                    # module is using the default. Older save paths only wrote
+                    # this field when ``_convrot_groupsize`` had been set
+                    # explicitly, which left on-the-fly-quantized layers with
+                    # an unspecified groupsize and forced the loader to fall
+                    # back to ``CONVROT_GROUP_SIZE`` (which happens to match
+                    # today, but is fragile if the default ever changes).
+                    if use_convrot:
+                        try:
+                            from .int8_quant import CONVROT_GROUP_SIZE
+                        except Exception:
+                            CONVROT_GROUP_SIZE = 256
+                        quant_conf["convrot_groupsize"] = int(
+                            getattr(module, "_convrot_groupsize", CONVROT_GROUP_SIZE)
+                        )
+
+                    # Track granularity so the loader can pick the matching
+                    # forward kernel without re-inspecting tensor shapes.
+                    quant_conf["per_row"] = bool(getattr(module, "_is_per_row", False))
+
+                    # Prepend 'model.' as comfy.sd.save_checkpoint adds this
+                    # prefix to all weights; extra_keys are NOT auto-prefixed
+                    # so we must do it ourselves to keep them aligned with the
+                    # owning weight tensor.
                     prefix = "model." + name + "." if name else "model."
-                    
+
                     extra_keys[prefix + "comfy_quant"] = torch.tensor(
                         list(json.dumps(quant_conf).encode('utf-8')), dtype=torch.uint8
                     )
-                    
-                    # 2. Handle scalar weight_scale which is not registered as a buffer
+
+                    # Handle scalar weight_scale which is not registered as a
+                    # persistent buffer (so it would be missing from
+                    # state_dict() entirely).
                     if getattr(module, "_weight_scale_scalar", None) is not None:
                         extra_keys[prefix + "weight_scale"] = torch.tensor(module._weight_scale_scalar)
 
@@ -132,6 +227,9 @@ class INT8ModelSave:
                 if had_flag:
                     module.comfy_patched_weights = old_flag
                 else:
-                    delattr(module, "comfy_patched_weights")
-                    
+                    try:
+                        delattr(module, "comfy_patched_weights")
+                    except AttributeError:
+                        pass
+
         return {}

--- a/int8_unet_loader.py
+++ b/int8_unet_loader.py
@@ -222,8 +222,18 @@ class UNetLoaderINTW8A8:
         # Wrap in custom patcher for unified LoRA support
         from .int8_quant import INT8ModelPatcher
         model = INT8ModelPatcher.clone(model)
-        model._safetensors_metadata = metadata  # stash for save node
-        
+        # Stash metadata in two places so it survives ModelPatcher.clone()
+        # (which is invoked by INT8GroupedLora and other downstream nodes).
+        # ModelPatcher.clone() returns a fresh patcher and does NOT carry over
+        # arbitrary attributes, but the inner `model.model` object is shared
+        # by reference, so attributes attached to it survive cloning.
+        model._safetensors_metadata = metadata  # legacy attribute
+        try:
+            if model.model is not None:
+                model.model._int8_source_metadata = metadata
+        except Exception:
+            pass
+
         return (model,)
 
 


### PR DESCRIPTION
## PR Summary
This pull request addresses checkpoint corruption when saving after INT8 Grouped LoRA applications, fixes a race condition where metadata was collected before LoRA patches were baked, and hardens the On-The-Fly (OTF) quantization round-trip path.

---

## Bug Fixes

### 🐛 Bug 1: Corrupted / unloadable checkpoints after INT8 Grouped LoRA save
* **Root Cause:** `ModelPatcher.clone()` constructs a fresh patcher but does not carry over arbitrary attributes attached to the source patcher (such as `_safetensors_metadata`). When `INT8GroupedLora.apply_loras()` called `model.clone()`, this metadata was lost. As a result, `INT8ModelSave` wrote checkpoints with empty metadata headers. This caused models like **LTX2** (which store transformer configs in the metadata) to fail to redetect on reload.
* **Fixes:**
  * `int8_unet_loader.py` (lines 225-235): Stash metadata in two places—on the patcher (legacy) and on the inner `model.model` object (`_int8_source_metadata`). Inner-model attributes safely survive `clone()` because the inner model is shared by reference.
  * `int8_lora.py` (lines 31-45): Implemented a best-effort copy of `_safetensors_metadata` and `_int8_source_metadata` from the source patcher onto the cloned patcher inside `INT8GroupedLora.apply_loras`.
  * `int8_save.py` (lines 12-40): Added a new `_resolve_source_metadata()` helper that walks the patcher -> parent chain with an inner-model fallback, and throws a warning if no metadata is found.

### 🐛 Bug 2: Save node collected `extra_keys` BEFORE LoRA baking
* **Root Cause:** `comfy.sd.save_checkpoint` internally triggers `load_models_gpu`, which is the exact moment `INT8ModelPatcher` bakes LoRA patches into the INT8 weights. Because the previous save node iterated over modules *before* this invocation, `mark_module_for_direct_save` and `comfy_quant` extra keys were being emitted against the pre-bake state. The saved bytes reflected the patched weights, but the metadata failed to cleanly capture the post-bake state.
* **Fix:**
  * `int8_save.py` (lines 120-154): Pre-call `comfy.model_management.load_models_gpu([model], force_full_load=True)` so all LoRA patches are baked and `comfy_patched_weights = True` is set on every module before walking the tree. It then re-finalizes any aimdo-deferred layers before collecting `extra_keys`.

### 🐛 Bug 3: Fragile OTF quantization round-trip
* **Root Cause:** OTF-quantized layers were never stamping `_convrot_groupsize` onto the module, forcing the save side to fall back to a loader-time default (`CONVROT_GROUP_SIZE = 256`). While this happened to match on reload for now, any future change to the default would silently corrupt files. Additionally, the saved `comfy_quant` JSON completely lacked the `convrot_groupsize` field.
* **Fixes:**
  * `int8_quant.py` (lines 254-257, 443-454): Explicitly set `self._convrot_groupsize = CONVROT_GROUP_SIZE` whenever OTF or deferred aimdo finalization applies a Hadamard rotation.
  * `int8_save.py` (lines 166-187): Always emit `convrot_groupsize` in `comfy_quant` whenever `convrot=True` (falling back to the module-level constant if missing). Also emit a `per_row` hint so the loader can select the matching forward kernel without re-inspecting tensor shapes.
  * `int8_quant.py` (lines 340-396): Parse the new `per_row` hint in `comfy_quant` to override the shape-based heuristic in `_load_from_state_dict`. (Legacy files lacking this hint will continue to work seamlessly via the original shape heuristic).