### PR TITLE
Fix "addmm_cuda" not implemented for 'Char'

### DIFF
--- a/int8_quant.py
+++ b/int8_quant.py
@@ -1035,6 +1035,9 @@ class INT8ModelPatcher(comfy.model_patcher.ModelPatcher):
                             module.weight_function = [f for f in getattr(module, "weight_function", []) if type(f).__name__ != "LowVramPatch"]
                         self.patch_weight_to_device(weight_key, device_to=device_to)
                     else:
+                        if hasattr(module, "weight_function"):
+                            module.weight_function = [f for f in getattr(module, "weight_function", []) if type(f).__name__ != "LowVramPatch"]
+                            
                         lowvram_patch = INT8LowVramPatch(
                             weight_key,
                             self.patches,


### PR DESCRIPTION
@gemini:

### Description
This PR fixes a critical crash that occurs during generation when attaching LoRAs via `INT8GroupedLora` (or standard LoRA loaders) while using the default bake-in modes (`None` or `Stochastic`).

**Error observed:**
`[ERROR] ERROR lora diffusion_model.transformer_blocks...weight "addmm_cuda" not implemented for 'Char'`

### Root Cause
In recent ComfyUI versions, a native `LowVramPatch` is automatically appended to `module.weight_function`. 
In `int8_quant.py`, the `dynamic_lora` branch correctly cleans up this native patch. However, the `else` branch (used for standard dequant-patch-requant bake-in via `INT8LowVramPatch`) missed this cleanup step. 

As a result, after `INT8LowVramPatch` successfully returns an INT8 (`Char`) tensor, ComfyUI's native patcher attempts to process it again using standard float matrix addition (`addmm`), which PyTorch cannot perform on INT8 tensors.

### Solution
Added a cleanup routine to the `else` branch in `INT8ModelPatcher.load()` to filter out `LowVramPatch` from `module.weight_function`, matching the logic already present in the dynamic branch.

```python
# Added to the else branch in INT8ModelPatcher.load()
if hasattr(module, "weight_function"):
    module.weight_function = [f for f in getattr(module, "weight_function", []) if type(f).__name__ != "LowVramPatch"]