### PR TITLE
Fix intermittent "addmm_cuda not implemented for 'Char'" on partial unload (#76)

### DIFF
--- a/int8_quant.py
+++ b/int8_quant.py
@@ -1018,6 +1018,29 @@ class INT8ModelPatcher(comfy.model_patcher.ModelPatcher):
         
         device_to = kwargs.get("device_to", args[0] if len(args) > 0 else self.model.device)
         
+        self._reinstall_int8_lowvram_patches(device_to)
+        
+        return res
+
+    def _reinstall_int8_lowvram_patches(self, device_to=None):
+        """Replace ComfyUI's stock LowVramPatch with our scale-aware INT8LowVramPatch
+        on every patched INT8 layer.
+
+        ComfyUI core installs a vanilla ``LowVramPatch`` whose ``__call__`` runs
+        ``calculate_weight(..., intermediate_dtype=weight.dtype)``. For an INT8
+        weight that intermediate dtype is ``torch.int8``, so the LoRA matmul hits
+        ``addmm_cuda not implemented for 'Char'`` (issue #76). We strip those stock
+        patches and route through INT8LowVramPatch, which dequantizes -> patches ->
+        re-quantizes with the per-row scale.
+
+        This must run after EVERY core path that can (re)install LowVramPatch on an
+        offloaded module: ``load()`` and ``partially_unload()``. The latter installs
+        the stock patch directly (model_patcher.py) without calling ``load()``, which
+        is why the crash was intermittent -- it only surfaced when memory pressure
+        triggered a partial unload of a patched layer.
+        """
+        save_materialized = bool(getattr(self, "_int8_save_materialized_lora", False))
+        
         for name, module in self.model.named_modules():
             if hasattr(module, "_is_quantized") and module._is_quantized:
                 weight_key = name + ".weight"
@@ -1048,7 +1071,13 @@ class INT8ModelPatcher(comfy.model_patcher.ModelPatcher):
                         if pin_state is not None:
                             lowvram_patch._pin_state = pin_state
                         module.weight_lowvram_function = lowvram_patch
-                    
+
+    def partially_unload(self, device_to, *args, **kwargs):
+        # ComfyUI core's partially_unload() re-installs a stock LowVramPatch on
+        # offloaded INT8 layers without going through load(), so re-run our swap
+        # to keep the scale-aware INT8LowVramPatch in place (issue #76).
+        res = super().partially_unload(device_to, *args, **kwargs)
+        self._reinstall_int8_lowvram_patches(device_to)
         return res
 
     def unpatch_model(self, device_to=None, unpatch_weights=True):


### PR DESCRIPTION
## Summary

Fixes the intermittent `"addmm_cuda" not implemented for 'Char'` crash reported in #76, which persisted even after the `load()`-only cleanup in c0cc280.

## Root cause

c0cc280 strips ComfyUI's stock `LowVramPatch` and swaps in the scale-aware `INT8LowVramPatch`, but **only inside `INT8ModelPatcher.load()`**.

ComfyUI core *also* installs a stock `LowVramPatch` on offloaded INT8 layers inside **`partially_unload()`** (`comfy/model_patcher.py`), and that path does **not** route through `load()`. The stock patch's `__call__` runs:

```python
calculate_weight(patches, weight, self.key, intermediate_dtype=weight.dtype)
```

For an INT8 weight the intermediate dtype is `torch.int8`, so the LoRA matmul hits `addmm_cuda not implemented for 'Char'`.

Because `partially_unload()` only fires under memory pressure — and only touches a memory-dependent subset of layers — the failure looked random and appeared to "fix itself" on reload. That matches the reports of the same LoRA working on some runs and failing on others.

## Fix

- Extract the `LowVramPatch` → `INT8LowVramPatch` swap out of `load()` into a shared `_reinstall_int8_lowvram_patches()` helper (behavior unchanged — all three branches preserved).
- Add a `partially_unload()` override that calls `super()` then re-runs the helper, so the scale-aware patch is restored after **every** core path that can install the stock one.

Net change: +30/-1, contained entirely within `INT8ModelPatcher`.

## Notes

I intentionally did **not** take the alternative "force `intermediate_dtype` to float32 for non-float weights" monkey-patch suggested in the issue. It would stop the traceback, but the stock `LowVramPatch` would then return a *float* weight with no re-quantization against the per-row scale — silently corrupting those layers instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)