### PR TITLE
fix: emit quant format key in INT8ModelSave; add MiniMax H3 model types

### DIFF
--- a/int8_save.py
+++ b/int8_save.py
@@ -218,7 +218,10 @@ class INT8ModelSave:
 
                 if getattr(module, "_is_quantized", False):
                     use_convrot = bool(getattr(module, "_use_convrot", False))
-                    quant_conf = {"convrot": use_convrot}
+                    # comfy.ops dispatches on this key; without it core's
+                    # UNETLoader raises "Unknown quantization format" and the
+                    # checkpoint only loads through our own loader.
+                    quant_conf = {"format": "int8_tensorwise", "convrot": use_convrot}
                     # Always emit a groupsize when convrot is on, even if the
                     # module is using the default. Older save paths only wrote
                     # this field when ``_convrot_groupsize`` had been set

--- a/int8_unet_loader.py
+++ b/int8_unet_loader.py
@@ -39,7 +39,7 @@ class UNetLoaderINTW8A8:
             "required": {
                 "unet_name": (folder_paths.get_filename_list("diffusion_models"),),
                 "weight_dtype": (["default", "fp16", "bf16", "fp32"], {"tooltip": "INT8 compute dtype. Default follows the model dtype, but uses fp16 for RTX 20/T4 sm75 GPUs and fp32 for GTX 16/unknown sm75 GPUs. Manual values force that dtype."}),
-                "model_type": (["flux2", "z-image", "ideogram4", "chroma", "krea2", "wan", "ltx2", "qwen", "ernie", "anima", "hidream o1", "boogu"], {"tooltip": "Only used for on the fly quantization, to filter sensitive layers."}),
+                "model_type": (["flux2", "z-image", "ideogram4", "chroma", "krea2", "wan", "ltx2", "qwen", "ernie", "anima", "hidream o1", "boogu", "minimax h3", "minimax h3 skip edges"], {"tooltip": "Only used for on the fly quantization, to filter sensitive layers."}),
                 "on_the_fly_quantization": ("BOOLEAN", {"default": False, "tooltip": "Quantize a higher precision model to INT8. If the selected model is already INT8 keep unchecked."}),
                 "enable_convrot": ("BOOLEAN", {"default": True, "tooltip": "Enable ConvRot for better quantization. ~1.1x slower, but near-GGUF_Q8 quality."}),
                 "lora_mode": (["None", "Stochastic", "Dynamic"], {"default": "None", "tooltip": "None bakes LoRA patches with normal rounding which is the default behavior. Stochastic bakes with stochastic INT8 rounding, which can occasionally be closer to the BF16+lora baseline. Dynamic applies LoRA at inference time, which is slow and only works for conventional lora."}),
@@ -147,6 +147,16 @@ class UNetLoaderINTW8A8:
             Int8TensorwiseOps.excluded_names = [
                 'patch_embedding', 'text_embedding', 'time_embedding', 'time_projection', 'head',
                 'img_emb', 'face_adapter', 'face_encoder', 'motion_encoder', 'pose_patch_embedding',
+            ]
+        elif model_type == "minimax h3":
+            Int8TensorwiseOps.excluded_names = [
+                'token_refiner', 'adaln', 'patch_proj', 'condition_proj', 'final_layer',
+            ]
+        elif model_type == "minimax h3 skip edges":
+            # As above, plus the first/last two transformer blocks.
+            Int8TensorwiseOps.excluded_names = [
+                'token_refiner', 'adaln', 'patch_proj', 'condition_proj', 'final_layer',
+                'blocks.0.', 'blocks.1.', 'blocks.48.', 'blocks.49.',
             ]
         elif model_type == "ltx2":
             Int8TensorwiseOps.excluded_names = [


### PR DESCRIPTION
### 1. `INT8ModelSave` writes checkpoints core ComfyUI can't load

`quant_conf` omits `format`, and `comfy/ops.py` dispatches on exactly that key, so any
checkpoint saved by this node fails in core's `UNETLoader`:

```
ValueError: Unknown quantization format for layer blocks.0.attn.qkv_proj
```

It loads fine through `OTUNetLoaderW8A8`, which detects int8 by tensor dtype — so the
breakage only shows up when someone uses the saved file with the native loader. Published
INT8 ConvRot checkpoints carry `{"format": "int8_tensorwise", "convrot": true,
"convrot_groupsize": 256}`; this makes the save node emit the same. Weights and scales are
unchanged, and core has native `int8_tensorwise` + ConvRot support.

### 2. MiniMax H3 model types (#95)

With no H3 entry the exclusion list is empty, so `adaln_proj` (in_features 8),
`video_patch_proj` (96) and `audio_patch_proj` (32) get quantized with no rotation — ConvRot
needs `in_features % 256 == 0`. Excluding them leaves the 200 `blocks.N` attn/mlp linears,
which is the layout of the H3 INT8 ConvRot checkpoints already in circulation.

`minimax h3 skip edges` additionally keeps blocks 0, 1, 48 and 49 in BF16, matching the
`_skip_edges` builds on HF (+~1.5 GB on a 21 GB checkpoint).

### Testing

10Eros Max H3 fl2va (BF16, 40 GB) quantized on a 5090 with both entries:

| model_type | quantized layers | size | core `UNETLoader` |
|---|---|---|---|
| `minimax h3` | 200 | 21.0 GB | loads |
| `minimax h3 skip edges` | 184 | 22.5 GB | loads |

All `comfy_quant` payloads decode to `{"format": "int8_tensorwise", "convrot": true,
"convrot_groupsize": 256, "per_row": true}`, and both files also still load through
`OTUNetLoaderW8A8` with on-the-fly quantization off.
